### PR TITLE
Improve unit testing setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: php
 php:
  - 5.6
-install: composer install
+install: composer install --prefer-source

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 web-chess
 ================
+Develop:
+[![Build Status](https://travis-ci.org/jupiter24/web-chess.svg?branch=develop)](https://travis-ci.org/jupiter24/web-chess)
+Master:
+[![Build Status](https://travis-ci.org/jupiter24/web-chess.svg?branch=master)](https://travis-ci.org/jupiter24/web-chess)
 
 A web implementation of a chess database program like SCID.
 

--- a/config/database.php
+++ b/config/database.php
@@ -26,7 +26,7 @@ return [
 	|
 	*/
 
-	'default' => 'mysql',
+	'default' => env('DB_DRIVER', 'mysql'),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -48,7 +48,7 @@ return [
 
 		'sqlite' => [
 			'driver'   => 'sqlite',
-			'database' => storage_path().'/database.sqlite',
+			'database' => ':memory:',
 			'prefix'   => '',
 		],
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,5 +19,6 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
+        <env name="DB_DRIVER" value="sqlite" />
     </php>
 </phpunit>

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -5,6 +5,7 @@ class UserTest extends TestCase
 	public function setUp()
 	{
 		parent::setUp();
+		\Artisan::call('migrate');
 		$this->seed('DatabaseSeeder');
 	}
 


### PR DESCRIPTION
Until now the database was reseeded every time a testsuite was run. First of all this is slow but it also overwrites any data in the tables. Another problem was that travis-ci build would fail because the database was not set up.
This PR fixes all of the above problems by using a in-memory sqlite database for phpunit.
Also .travis.yml has been changed to let travis-ci download packages from source directly.
