### PR TITLE
[WIP - Don't merge!] Use PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: php
 php:
- - 5.6
+ - 7.0
 install: composer install --prefer-source

--- a/app/Chess/Position.php
+++ b/app/Chess/Position.php
@@ -877,20 +877,8 @@ class Position
                 // the rest of this function basically checks if there is any piece between departure and destination because rooks cannot jump
 
                 // get the direction of movement (-1, 0 or 1)
-                if ((getFile($destination) - getFile($departure)) == 0) {
-                    $fileMovement = 0;
-                } elseif ((getFile($destination) - getFile($departure)) > 0) {
-                    $fileMovement = 1;
-                } elseif ((getFile($destination) - getFile($departure)) < 0) {
-                    $fileMovement = -1;
-                }
-                if ((getRank($destination) - getRank($departure)) == 0) {
-                    $rankMovement = 0;
-                } elseif ((getRank($destination) - getRank($departure)) > 0) {
-                    $rankMovement = 1;
-                } elseif ((getRank($destination) - getRank($departure)) < 0) {
-                    $rankMovement = -1;
-                }
+                $fileMovement = getFile($destination) <=> getFile($departure);
+                $rankMovement = getRank($destination) <=> getRank($departure);
 
                 $file = getFile($departure) + $fileMovement;
                 $rank = getRank($departure) + $rankMovement;
@@ -910,20 +898,8 @@ class Position
 
                 // the rest of this function basically checks if there is any piece between departure and destination because bishops cannot jump
 
-                if ((getFile($destination) - getFile($departure)) == 0) {
-                    $fileMovement = 0;
-                } elseif ((getFile($destination) - getFile($departure)) > 0) {
-                    $fileMovement = 1;
-                } elseif ((getFile($destination) - getFile($departure)) < 0) {
-                    $fileMovement = -1;
-                }
-                if ((getRank($destination) - getRank($departure)) == 0) {
-                    $rankMovement = 0;
-                } elseif ((getRank($destination) - getRank($departure)) > 0) {
-                    $rankMovement = 1;
-                } elseif ((getRank($destination) - getRank($departure)) < 0) {
-                    $rankMovement = -1;
-                }
+                $fileMovement = getFile($destination) <=> getFile($departure);
+                $rankMovement = getRank($destination) <=> getRank($departure);
 
                 $file = getFile($departure) + $fileMovement;
                 $rank = getRank($departure) + $rankMovement;
@@ -941,20 +917,8 @@ class Position
 
                 // the rest of this function basically checks if there is any piece between departure and destination because queens cannot jump
 
-                if ((getFile($destination) - getFile($departure)) == 0) {
-                    $fileMovement = 0;
-                } elseif ((getFile($destination) - getFile($departure)) > 0) {
-                    $fileMovement = 1;
-                } elseif ((getFile($destination) - getFile($departure)) < 0) {
-                    $fileMovement = -1;
-                }
-                if ((getRank($destination) - getRank($departure)) == 0) {
-                    $rankMovement = 0;
-                } elseif ((getRank($destination) - getRank($departure)) > 0) {
-                    $rankMovement = 1;
-                } elseif ((getRank($destination) - getRank($departure)) < 0) {
-                    $rankMovement = -1;
-                }
+                $fileMovement = getFile($destination) <=> getFile($departure);
+                $rankMovement = getRank($destination) <=> getRank($departure);
 
                 $file = getFile($departure) + $fileMovement;
                 $rank = getRank($departure) + $rankMovement;

--- a/app/Criteria/GameHasTagRequestCriterion.php
+++ b/app/Criteria/GameHasTagRequestCriterion.php
@@ -3,8 +3,10 @@
 use Auth;
 use DB;
 use Illuminate\Http\Request;
-use Prettus\Repository\Contracts\CriteriaInterface;
-use Prettus\Repository\Contracts\RepositoryInterface;
+use Prettus\Repository\Contracts\{
+    CriteriaInterface,
+    RepositoryInterface
+};
 
 /**
  * Class GameHasTagRequestCriterion.

--- a/app/Criteria/VisibleGameCriterion.php
+++ b/app/Criteria/VisibleGameCriterion.php
@@ -2,8 +2,10 @@
 
 use Auth;
 use DB;
-use Prettus\Repository\Contracts\CriteriaInterface;
-use Prettus\Repository\Contracts\RepositoryInterface;
+use Prettus\Repository\Contracts\{
+    CriteriaInterface,
+    RepositoryInterface
+};
 
 /**
  * Class VisibleGameCriterion

--- a/app/Criteria/VisibleTagCriterion.php
+++ b/app/Criteria/VisibleTagCriterion.php
@@ -2,8 +2,10 @@
 
 use Auth;
 use DB;
-use Prettus\Repository\Contracts\CriteriaInterface;
-use Prettus\Repository\Contracts\RepositoryInterface;
+use Prettus\Repository\Contracts\{
+    CriteriaInterface,
+    RepositoryInterface
+};
 
 /**
  * Class VisibleTagCriterion

--- a/app/Entities/Game.php
+++ b/app/Entities/Game.php
@@ -1,8 +1,10 @@
 <?php namespace App\Entities;
 
 use Illuminate\Database\Eloquent\Model;
-use Prettus\Repository\Contracts\Presentable;
-use Prettus\Repository\Traits\PresentableTrait;
+use Prettus\Repository\{
+    Contracts\Presentable,
+    Traits\PresentableTrait
+};
 use App\Chess\BCFGame;
 
 class Game extends Model implements Presentable

--- a/app/Entities/Tag.php
+++ b/app/Entities/Tag.php
@@ -3,8 +3,10 @@
 namespace App\Entities;
 
 use Illuminate\Database\Eloquent\Model;
-use Prettus\Repository\Contracts\Presentable;
-use Prettus\Repository\Traits\PresentableTrait;
+use Prettus\Repository\{
+    Contracts\Presentable,
+    Traits\PresentableTrait
+};
 
 class Tag extends Model implements Presentable
 {

--- a/app/Entities/User.php
+++ b/app/Entities/User.php
@@ -7,8 +7,10 @@ use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
-use Prettus\Repository\Contracts\Presentable;
-use Prettus\Repository\Traits\PresentableTrait;
+use Prettus\Repository\{
+    Contracts\Presentable,
+    Traits\PresentableTrait
+};
 
 class User extends Model implements AuthenticatableContract, AuthorizableContract, CanResetPasswordContract, Presentable
 {

--- a/app/Policies/GamePolicy.php
+++ b/app/Policies/GamePolicy.php
@@ -3,8 +3,10 @@
 namespace App\Policies;
 
 use Illuminate\Auth\Access\HandlesAuthorization;
-use App\Entities\User;
-use App\Entities\Game;
+use App\Entities\{
+    User,
+    Game
+};
 
 class GamePolicy
 {

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -3,8 +3,10 @@
 namespace App\Policies;
 
 use Illuminate\Auth\Access\HandlesAuthorization;
-use App\Entities\User;
-use App\Entities\Tag;
+use App\Entities\{
+    User,
+    Tag
+};
 
 class TagPolicy
 {

--- a/app/Transformers/GameSummaryTransformer.php
+++ b/app/Transformers/GameSummaryTransformer.php
@@ -20,8 +20,8 @@ class GameSummaryTransformer extends TransformerAbstract
     public function transform(Game $model)
     {
         return array_filter([
-            'id'         => isset($model->id)         ? (int) $model->id                      : null,
-            'owner_id'   => isset($model->owner_id)   ? $model->owner_id                      : null,
+            'id'         => $model->id       ?? null,
+            'owner_id'   => $model->owner_id ?? null,
             'created_at' => isset($model->created_at) ? $model->created_at->toIso8601String() : null,
         ]);
     }

--- a/app/Transformers/GameTagTransformer.php
+++ b/app/Transformers/GameTagTransformer.php
@@ -30,9 +30,9 @@ class GameTagTransformer extends TransformerAbstract
     public function transform(Tag $model)
     {
         return array_filter([
-            'id'          => isset($model->id)         ? (int) $model->id                      : null,
-            'name'        => isset($model->name)       ? $model->name                          : null,
-            'owner_id'    => isset($model->owner_id)   ? $model->owner_id                      : null,
+            'id'          => $modle->id             ?? null,
+            'name'        => $model->name           ?? null,
+            'owner_id'    => $model->owner_id       ?? null,
             'created_at'  => isset($model->created_at) ? $model->created_at->toIso8601String() : null,
             'attached_at' => isset($model->pivot->created_at) ? $model->pivot->created_at->toIso8601String() : null,
         ]);

--- a/app/Transformers/GameTransformer.php
+++ b/app/Transformers/GameTransformer.php
@@ -32,9 +32,9 @@ class GameTransformer extends TransformerAbstract
     public function transform(Game $model)
     {
         return array_filter([
-            'id'         => isset($model->id)         ? (int) $model->id                      : null,
-            'owner_id'   => isset($model->owner_id)   ? $model->owner_id                      : null,
-            'public'     => isset($model->public)     ? (int) $model->public                  : null,
+            'id'         => $model->id             ?? null,
+            'owner_id'   => $model->owner_id       ?? null,
+            'public'     => $model->public         ?? null,
             'jcf'        => isset($model->game)       ? $model->game->jsonSerialize()         : null,
             'created_at' => isset($model->created_at) ? $model->created_at->toIso8601String() : null,
             'updated_at' => isset($model->updated_at) ? $model->updated_at->toIso8601String() : null,

--- a/app/Transformers/TagSummaryTransformer.php
+++ b/app/Transformers/TagSummaryTransformer.php
@@ -20,9 +20,9 @@ class TagSummaryTransformer extends TransformerAbstract
     public function transform(Tag $model)
     {
         return array_filter([
-            'id'         => isset($model->id)         ? (int) $model->id                      : null,
-            'name'       => isset($model->name)       ? $model->name                          : null,
-            'owner_id'   => isset($model->owner_id)   ? $model->owner_id                      : null,
+            'id'         => $model->id            ?? null,
+            'name'       => $model->name          ?? null,
+            'owner_id'   => $model->owner_id      ?? null,
             'created_at' => isset($model->created_at) ? $model->created_at->toIso8601String() : null,
         ]);
     }

--- a/app/Transformers/TagTransformer.php
+++ b/app/Transformers/TagTransformer.php
@@ -32,10 +32,10 @@ class TagTransformer extends TransformerAbstract
     public function transform(Tag $model)
     {
         return array_filter([
-            'id'         => isset($model->id)         ? (int) $model->id                      : null,
-            'name'       => isset($model->name)       ? $model->name                          : null,
-            'public'     => isset($model->public)     ? (int) $model->public                        : null,
-            'owner_id'   => isset($model->owner_id)   ? $model->owner_id                      : null,
+            'id'         => $model->id            ?? null,
+            'name'       => $model->name          ?? null,
+            'public'     => $model->public        ?? null,
+            'owner_id'   => $model->owner_id      ?? null,
             'created_at' => isset($model->created_at) ? $model->created_at->toIso8601String() : null,
             'updated_at' => isset($model->updated_at) ? $model->updated_at->toIso8601String() : null,
         ], function ($v) {

--- a/app/Transformers/UserSummaryTransformer.php
+++ b/app/Transformers/UserSummaryTransformer.php
@@ -20,8 +20,8 @@ class UserSummaryTransformer extends TransformerAbstract
     public function transform(User $model)
     {
         return array_filter([
-            'id'         => isset($model->id)         ? (int) $model->id                      : null,
-            'name'       => isset($model->name)       ? $model->name                          : null,
+            'id'         => $model->id             ?? null,
+            'name'       => $model->name           ?? null,
             'created_at' => isset($model->created_at) ? $model->created_at->toIso8601String() : null,
         ]);
     }

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -30,9 +30,9 @@ class UserTransformer extends TransformerAbstract
     public function transform(User $model)
     {
         return array_filter([
-            'id'         => isset($model->id)         ? (int) $model->id                      : null,
-            'name'       => isset($model->name)       ? $model->name                          : null,
-            'email'      => isset($model->email)      ? $model->email                         : null,
+            'id'         => $model->id             ?? null,
+            'name'       => $model->name           ?? null,
+            'email'      => $model->email          ?? null,
             'created_at' => isset($model->created_at) ? $model->created_at->toIso8601String() : null,
             'updated_at' => isset($model->updated_at) ? $model->updated_at->toIso8601String() : null,
         ]);


### PR DESCRIPTION
PHP 7 has many improvements over PHP 5.
Grouped imports, null coalescing (??) and combined comparison (spaceship operator, <=>) are used with this PR, type declarations are still on the TODO-list.

However, StyleCi doesn't seem to support PHP 7 yet, so it just gives an error.

Things for discussion:
- should we support PHP 5? I personally don't think so.
- how extensively should type declarations be used? I think we should use scalar type hinting in the Chess API (instead of is_int, ...) but not return type declaration except for interfaces.
